### PR TITLE
Refactor horseshoe to equipment slot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
   modImplementation "net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}"
 }
 
+loom {
+  accessWidenerPath = file("src/main/resources/vshorses.accesswidener")
+}
+
 processResources {
   inputs.property "version", project.version
 

--- a/src/main/java/com/vanillastar/vshorses/mixin/block/DispenserBehaviorMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/block/DispenserBehaviorMixin.java
@@ -44,8 +44,8 @@ public interface DispenserBehaviorMixin {
           if (candidates.isEmpty()) {
             return super.dispenseSilently(pointer, stack);
           }
-          ((VSHorseEntity) candidates.getFirst()).vshorses$setHorseshoeInInventory(
-            stack.split(1));
+          ((VSHorseEntity) candidates.getFirst()).vshorses$getHorseshoeInventory()
+            .setStack(stack.split(1));
           this.setSuccess(true);
           return stack;
         }

--- a/src/main/java/com/vanillastar/vshorses/mixin/entity/AbstractHorseEntityMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/entity/AbstractHorseEntityMixin.java
@@ -4,19 +4,15 @@ import com.vanillastar.vshorses.entity.VSHorseEntity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
-import net.minecraft.entity.attribute.EntityAttributeInstance;
-import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.passive.AbstractHorseEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.inventory.Inventory;
-import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.inventory.SingleStackInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
@@ -31,31 +27,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import static com.vanillastar.vshorses.entity.VSHorseEntityHelperKt.EQUIP_HORSESHOE_SOUND;
 import static com.vanillastar.vshorses.entity.VSHorseEntityHelperKt.isHorselike;
 import static com.vanillastar.vshorses.item.HorseshoeItemKt.HORSESHOE_ITEM;
-import static com.vanillastar.vshorses.utils.IdentiferHelperKt.getModIdentifier;
 
 @Mixin(AbstractHorseEntity.class)
 public abstract class AbstractHorseEntityMixin extends AnimalEntity implements VSHorseEntity {
-  /**
-   * {@code HORSE_FLAGS} value for horseshoe equipped status.
-   * <p>
-   * This is the next flag after {@code EATING_FLAG = 64}.
-   */
-  @Unique
-  private static final int SHOED_FLAG = 128;
-
   /**
    * NBT tag name for the entity's horseshoe inventory slot.
    */
   @Unique
   private static final String HORSESHOE_INVENTORY_SLOT_NBT_TAG =
     "HorseshoeItem";
-
-  /**
-   * ID for the {@link EntityAttributeModifier} that makes shoed horses faster.
-   */
-  @Unique
-  private static final Identifier HORSESHOE_SPEED_MODIFIER_ID =
-    getModIdentifier("horseshoe_boost");
 
   /**
    * Number of ticks of travel each horseshoe durability point affords.
@@ -71,20 +51,50 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
   @Unique
   private int movingWhileRiddenTicks = 0;
 
-  @Shadow
-  protected SimpleInventory items;
+  /**
+   * Pseudo-inventory in which to hold a horseshoe.
+   * <p>
+   * All inventory accesses and updates are redirected to the entity's
+   * equipment slots.
+   */
+  @Unique
+  private final SingleStackInventory horseshoeInventory =
+    new SingleStackInventory() {
+      @Override
+      public ItemStack getStack() {
+        return AbstractHorseEntityMixin.this.getEquippedStack(HORSESHOE_ITEM.getEquipmentSlot());
+      }
+
+      @Override
+      public void setStack(ItemStack stack) {
+        if (!stack.isEmpty()) {
+          // Same hack as in `AbstractHorseEntity.onInventoryChanged` to
+          // suppress sound playback upon entity initialization.
+          if (AbstractHorseEntityMixin.this.age > 20) {
+            AbstractHorseEntityMixin.this.playSound(EQUIP_HORSESHOE_SOUND,
+              0.5F,
+              1.0F
+            );
+          }
+        }
+        AbstractHorseEntityMixin.this.equipLootStack(HORSESHOE_ITEM.getEquipmentSlot(),
+          stack
+        );
+      }
+
+      @Override
+      public void markDirty() {
+      }
+
+      @Override
+      public boolean canPlayerUse(PlayerEntity player) {
+        return player.getVehicle() == AbstractHorseEntityMixin.this ||
+          player.canInteractWithEntity(AbstractHorseEntityMixin.this, 4.0);
+      }
+    };
 
   @Shadow
   public abstract boolean canBeSaddled();
-
-  @Shadow
-  protected abstract boolean getHorseFlag(int bitmask);
-
-  @Shadow
-  protected abstract void setHorseFlag(int bitmask, boolean flag);
-
-  @Shadow
-  public abstract int getInventorySize();
 
   private AbstractHorseEntityMixin(
     EntityType<? extends AnimalEntity> entityType, World world
@@ -94,16 +104,21 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
 
   @Override
   public int vshorses$getHorseshoeScreenSlot() {
-    // Screen slot 0 is for saddle. Screen slot 1 is for horse armor if
-    // applicable.
+    // Screen slot 0 is for saddle. Screen slot 1 is for horse armor, even if
+    // the entity does not support wearing it.
+    return 2;
+  }
+
+  @Override
+  public int vshorses$getHorseshoeScreenDrawSlot() {
+    // Drawn screen slot 0 is for saddle. Drawn screen slot 1 is for horse armor
+    // if applicable.
     return this.canUseSlot(EquipmentSlot.BODY) ? 2 : 1;
   }
 
   @Override
-  public int vshorses$getHorseshoeInventorySlot() {
-    // Set horseshoe inventory slot to end of the inventory to prevent collision
-    // with any storage inventory slots.
-    return this.getInventorySize() - 1;
+  public @NotNull SingleStackInventory vshorses$getHorseshoeInventory() {
+    return this.horseshoeInventory;
   }
 
   @Override
@@ -113,26 +128,7 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
 
   @Override
   public boolean vshorses$isShoed() {
-    return this.getHorseFlag(SHOED_FLAG);
-  }
-
-  @Override
-  public @NotNull ItemStack vshorses$getHorseshoeInInventory() {
-    return this.items.getStack(this.vshorses$getHorseshoeInventorySlot());
-  }
-
-  @Override
-  public void vshorses$setHorseshoeInInventory(@NotNull ItemStack stack) {
-    this.items.setStack(this.vshorses$getHorseshoeInventorySlot(), stack);
-  }
-
-  @Unique
-  protected void updateShoedFlag() {
-    if (!this.getWorld().isClient) {
-      this.setHorseFlag(SHOED_FLAG,
-        this.vshorses$getHorseshoeInInventory().isOf(HORSESHOE_ITEM)
-      );
-    }
+    return this.horseshoeInventory.getStack().isOf(HORSESHOE_ITEM);
   }
 
   @Inject(
@@ -145,45 +141,6 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
   ) {
     cir.setReturnValue(cir.getReturnValue()
       .add(EntityAttributes.GENERIC_WATER_MOVEMENT_EFFICIENCY, 0.3D));
-  }
-
-  @Inject(
-    method = "getInventorySize(I)I", at = @At("RETURN"), cancellable = true
-  )
-  private static void getShoeableInventorySize(
-    int columns, @NotNull CallbackInfoReturnable<Integer> cir
-  ) {
-    // This makes all `AbstractHorseEntity`'s have inventory space for
-    // horseshoes, but this is less painful than modifying this static method to
-    // read the instance's `EntityType`.
-    cir.setReturnValue(cir.getReturnValue() + 1);
-    cir.cancel();
-  }
-
-  @Inject(method = "onInventoryChanged", at = @At("TAIL"))
-  private void onHorseshoeInventoryChanged(Inventory sender, CallbackInfo ci) {
-    EntityAttributeInstance speedAttributeInstance =
-      this.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED);
-    assert speedAttributeInstance != null;
-
-    boolean wasPreviouslyShoed = this.vshorses$isShoed();
-    this.updateShoedFlag();
-    if (!this.vshorses$isShoed()) {
-      speedAttributeInstance.removeModifier(HORSESHOE_SPEED_MODIFIER_ID);
-      return;
-    }
-    if (wasPreviouslyShoed) {
-      // No change in horseshoe equipped status.
-      return;
-    }
-
-    speedAttributeInstance.addTemporaryModifier(HORSESHOE_ITEM.getSpeedModifierWithId(
-      HORSESHOE_SPEED_MODIFIER_ID));
-    // Same hack as in `AbstractHorseEntity.onInventoryChanged` to suppress
-    // sound playback upon entity initialization.
-    if (this.age > 20) {
-      this.playSound(EQUIP_HORSESHOE_SOUND, 0.5F, 1.0F);
-    }
   }
 
   @Inject(method = "tickControlled", at = @At("TAIL"))
@@ -206,20 +163,19 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
     movingWhileRiddenTicks =
       (movingWhileRiddenTicks + 1) % TICKS_PER_HORSESHOE_DAMAGE;
     if (movingWhileRiddenTicks == 0) {
-      this.vshorses$getHorseshoeInInventory()
-        .damage(1, serverWorld, null, item -> {
-          // Volume and pitch from `LivingEntity.playEquipmentBreakEffects`.
-          this.playSound(item.getBreakSound(),
-            0.8F,
-            0.8F + this.getWorld().random.nextFloat() * 0.4F
-          );
-        });
+      this.horseshoeInventory.getStack().damage(1, serverWorld, null, item -> {
+        // Volume and pitch from `LivingEntity.playEquipmentBreakEffects`.
+        this.playSound(item.getBreakSound(),
+          0.8F,
+          0.8F + this.getWorld().random.nextFloat() * 0.4F
+        );
+      });
     }
   }
 
   @Inject(method = "writeCustomDataToNbt", at = @At("TAIL"))
   private void writeHorseshoeDataToNbt(NbtCompound nbt, CallbackInfo ci) {
-    ItemStack stack = this.vshorses$getHorseshoeInInventory();
+    ItemStack stack = this.horseshoeInventory.getStack();
     if (!stack.isEmpty()) {
       nbt.put(HORSESHOE_INVENTORY_SLOT_NBT_TAG,
         stack.encode(this.getRegistryManager())
@@ -231,16 +187,16 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
   private void readHorseshoeDataFromNbt(
     @NotNull NbtCompound nbt, CallbackInfo ci
   ) {
-    if (nbt.contains(HORSESHOE_INVENTORY_SLOT_NBT_TAG,
+    if (!nbt.contains(HORSESHOE_INVENTORY_SLOT_NBT_TAG,
       NbtElement.COMPOUND_TYPE
     )) {
-      ItemStack stack = ItemStack.fromNbt(this.getRegistryManager(),
-        nbt.getCompound(HORSESHOE_INVENTORY_SLOT_NBT_TAG)
-      ).orElse(ItemStack.EMPTY);
-      if (stack.isOf(HORSESHOE_ITEM)) {
-        this.vshorses$setHorseshoeInInventory(stack);
-      }
+      return;
     }
-    this.updateShoedFlag();
+    ItemStack stack = ItemStack.fromNbt(this.getRegistryManager(),
+      nbt.getCompound(HORSESHOE_INVENTORY_SLOT_NBT_TAG)
+    ).orElse(ItemStack.EMPTY);
+    if (stack.isOf(HORSESHOE_ITEM)) {
+      this.horseshoeInventory.setStack(stack);
+    }
   }
 }

--- a/src/main/java/com/vanillastar/vshorses/mixin/screen/HorseScreenHandlerMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/screen/HorseScreenHandlerMixin.java
@@ -70,6 +70,7 @@ public abstract class HorseScreenHandlerMixin extends ScreenHandler {
     this.addSlot(new ArmorSlot(vsHorseEntity.vshorses$getHorseshoeInventory(),
       entity,
       EquipmentSlot.FEET,
+      // This is a pseudo-inventory with size 1, so 0 is the only index.
       0,
       8,
       INVENTORY_SLOT_SIZE_PX *

--- a/src/main/java/com/vanillastar/vshorses/mixin/screen/HorseScreenHandlerMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/screen/HorseScreenHandlerMixin.java
@@ -1,25 +1,40 @@
 package com.vanillastar.vshorses.mixin.screen;
 
 import com.vanillastar.vshorses.entity.VSHorseEntity;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.passive.AbstractHorseEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.HorseScreenHandler;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.screen.slot.ArmorSlot;
 import net.minecraft.screen.slot.Slot;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.vanillastar.vshorses.entity.VSHorseEntityHelperKt.isHorselike;
 import static com.vanillastar.vshorses.item.HorseshoeItemKt.HORSESHOE_ITEM;
 import static com.vanillastar.vshorses.utils.ScreenHelperKt.INVENTORY_SLOT_SIZE_PX;
 
 @Mixin(HorseScreenHandler.class)
 public abstract class HorseScreenHandlerMixin extends ScreenHandler {
+  @Shadow
+  @Final
+  private Inventory inventory;
+
+  @Shadow
+  @Final
+  private AbstractHorseEntity entity;
+
   private HorseScreenHandlerMixin(
     @Nullable ScreenHandlerType<HorseScreenHandler> type, int syncId
   ) {
@@ -52,12 +67,14 @@ public abstract class HorseScreenHandlerMixin extends ScreenHandler {
       return;
     }
 
-    this.addSlot(new Slot(
-      inventory,
-      vsHorseEntity.vshorses$getHorseshoeInventorySlot(),
+    this.addSlot(new ArmorSlot(vsHorseEntity.vshorses$getHorseshoeInventory(),
+      entity,
+      EquipmentSlot.FEET,
+      0,
       8,
       INVENTORY_SLOT_SIZE_PX *
-        (vsHorseEntity.vshorses$getHorseshoeScreenSlot() + 1)
+        (vsHorseEntity.vshorses$getHorseshoeScreenDrawSlot() + 1),
+      null
     ) {
       @Override
       public boolean canInsert(ItemStack stack) {
@@ -71,5 +88,68 @@ public abstract class HorseScreenHandlerMixin extends ScreenHandler {
         return vsHorseEntity.vshorses$canBeShoed();
       }
     });
+  }
+
+  @Inject(method = "quickMove", at = @At("HEAD"), cancellable = true)
+  private void supportHorseshoeInQuickMove(
+    PlayerEntity player, int screenSlot, CallbackInfoReturnable<ItemStack> cir
+  ) {
+    if (!isHorselike(this.entity) ||
+      !(this.entity instanceof VSHorseEntity vsHorseEntity)) {
+      return;
+    }
+
+    Slot screenSlotRef = this.slots.get(screenSlot);
+    if (!screenSlotRef.hasStack()) {
+      // Nothing to quick-move from screen slot.
+      cir.setReturnValue(ItemStack.EMPTY);
+      cir.cancel();
+      return;
+    }
+
+    ItemStack itemStack = screenSlotRef.getStack();
+    ItemStack itemStackCopy = itemStack.copy();
+    int horseshoeScreenSlot = vsHorseEntity.vshorses$getHorseshoeScreenSlot();
+    // Entity's screen inventory size, including the sizes of its pseudo-
+    // inventories (horse armor, horseshoe).
+    int screenInventorySize = this.inventory.size() + 2;
+
+    if (screenSlot < screenInventorySize) {
+      // Screen slot is in entity's screen inventory. Try quick-moving to all
+      // other screen slots.
+      if (!this.insertItem(itemStackCopy,
+        screenInventorySize,
+        this.slots.size(),
+        true
+      )) {
+        cir.setReturnValue(ItemStack.EMPTY);  // Quick-move failed
+        cir.cancel();
+        return;
+      }
+    } else if (this.getSlot(horseshoeScreenSlot).canInsert(itemStackCopy) &&
+      !this.getSlot(horseshoeScreenSlot).hasStack()) {
+      // Entity's horseshoe screen slot can accept this item. Try quick-moving
+      // to there.
+      if (!this.insertItem(itemStackCopy,
+        horseshoeScreenSlot,
+        horseshoeScreenSlot + 1,
+        false
+      )) {
+        cir.setReturnValue(ItemStack.EMPTY);  // Quick-move failed
+        cir.cancel();
+        return;
+      }
+    } else {
+      // Defer to existing implementation.
+      return;
+    }
+
+    if (itemStackCopy.isEmpty()) {
+      screenSlotRef.setStack(ItemStack.EMPTY);
+    } else {
+      screenSlotRef.markDirty();
+    }
+    cir.setReturnValue(itemStack);
+    cir.cancel();
   }
 }

--- a/src/main/java/com/vanillastar/vshorses/mixin/screen/HorseScreenMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/screen/HorseScreenMixin.java
@@ -64,9 +64,13 @@ public abstract class HorseScreenMixin extends HandledScreen<HorseScreenHandler>
       return;
     }
 
-    context.drawGuiTexture(HORSESHOE_SLOT_SPRITE_ID, i + 7, j + (
-      INVENTORY_SLOT_SIZE_PX *
-        (vsHorseEntity.vshorses$getHorseshoeScreenDrawSlot() + 1)
-    ) - 1, INVENTORY_SLOT_SIZE_PX, INVENTORY_SLOT_SIZE_PX);
+    int screenDrawSlot = vsHorseEntity.vshorses$getHorseshoeScreenDrawSlot();
+    context.drawGuiTexture(
+      HORSESHOE_SLOT_SPRITE_ID,
+      i + 7,
+      j + (INVENTORY_SLOT_SIZE_PX * (screenDrawSlot + 1)) - 1,
+      INVENTORY_SLOT_SIZE_PX,
+      INVENTORY_SLOT_SIZE_PX
+    );
   }
 }

--- a/src/main/java/com/vanillastar/vshorses/mixin/screen/HorseScreenMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/screen/HorseScreenMixin.java
@@ -64,13 +64,9 @@ public abstract class HorseScreenMixin extends HandledScreen<HorseScreenHandler>
       return;
     }
 
-    int screenSlot = vsHorseEntity.vshorses$getHorseshoeScreenSlot();
-    context.drawGuiTexture(
-      HORSESHOE_SLOT_SPRITE_ID,
-      i + 7,
-      j + (INVENTORY_SLOT_SIZE_PX * (screenSlot + 1)) - 1,
-      INVENTORY_SLOT_SIZE_PX,
-      INVENTORY_SLOT_SIZE_PX
-    );
+    context.drawGuiTexture(HORSESHOE_SLOT_SPRITE_ID, i + 7, j + (
+      INVENTORY_SLOT_SIZE_PX *
+        (vsHorseEntity.vshorses$getHorseshoeScreenDrawSlot() + 1)
+    ) - 1, INVENTORY_SLOT_SIZE_PX, INVENTORY_SLOT_SIZE_PX);
   }
 }

--- a/src/main/kotlin/com/vanillastar/vshorses/entity/VSHorseEntity.kt
+++ b/src/main/kotlin/com/vanillastar/vshorses/entity/VSHorseEntity.kt
@@ -6,8 +6,8 @@ import net.minecraft.inventory.SingleStackInventory
 @Suppress("FunctionName")  // Mixin method name convention
 interface VSHorseEntity {
   /**
-   * Gets the 0-indexed slot at which the horseshoe slot in the entity's
-   * inventory screen is set.
+   * Gets the 0-indexed slot at which to **set** the horseshoe slot in the
+   * entity's inventory screen.
    *
    * For example, a horse's inventory screen will have saddle set at 0,
    * horse armor at 1, and horseshoe at 2. Same for a donkey's, even though
@@ -17,8 +17,8 @@ interface VSHorseEntity {
   fun `vshorses$getHorseshoeScreenSlot`(): Int
 
   /**
-   * Gets the 0-indexed slot at which to draw the horseshoe slot in the entity's
-   * inventory screen.
+   * Gets the 0-indexed slot at which to **draw** the horseshoe slot in the
+   * entity's inventory screen.
    *
    * For example, a horse's inventory screen will have saddle drawn at 0, horse
    * armor at 1, and horseshoe at 2. A donkey's will have saddle drawn at 0 and

--- a/src/main/kotlin/com/vanillastar/vshorses/entity/VSHorseEntity.kt
+++ b/src/main/kotlin/com/vanillastar/vshorses/entity/VSHorseEntity.kt
@@ -1,35 +1,43 @@
 package com.vanillastar.vshorses.entity
 
-import net.minecraft.item.ItemStack
+import net.minecraft.entity.passive.AbstractHorseEntity
+import net.minecraft.inventory.SingleStackInventory
 
 @Suppress("FunctionName")  // Mixin method name convention
 interface VSHorseEntity {
   /**
-   * Gets the 0-indexed slot at which to draw the horseshoe slot in the entity's
-   * inventory screen.
+   * Gets the 0-indexed slot at which the horseshoe slot in the entity's
+   * inventory screen is set.
    *
-   * For example, a horse's inventory screen will have saddle at 0, horse armor
-   * at 1, and horseshoe at 2.
+   * For example, a horse's inventory screen will have saddle set at 0,
+   * horse armor at 1, and horseshoe at 2. Same for a donkey's, even though
+   * donkeys cannot wear horse armor and its respective screen slot is never
+   * drawn.
    */
   fun `vshorses$getHorseshoeScreenSlot`(): Int
 
   /**
-   * Gets the 0-indexed slot at which to store the horseshoe in the entity's
-   * inventory.
+   * Gets the 0-indexed slot at which to draw the horseshoe slot in the entity's
+   * inventory screen.
    *
-   * For example, a horse will have saddle at 0 and horseshoe at 1.
+   * For example, a horse's inventory screen will have saddle drawn at 0, horse
+   * armor at 1, and horseshoe at 2. A donkey's will have saddle drawn at 0 and
+   * horseshoe at 1.
    */
-  fun `vshorses$getHorseshoeInventorySlot`(): Int
+  fun `vshorses$getHorseshoeScreenDrawSlot`(): Int
+
+  /**
+   * Gets the inventory dedicated to holding a horseshoe.
+   *
+   * [AbstractHorseEntity] inventory is dedicated only to storage. Saddle is
+   * stored as a flag, and horse armor is stored in a separate
+   * [SingleStackInventory] simply called `inventory`.
+   */
+  fun `vshorses$getHorseshoeInventory`(): SingleStackInventory
 
   /** Whether the entity supports wearing horseshoes. */
   fun `vshorses$canBeShoed`(): Boolean
 
   /** Whether the entity is wearing a horseshoe. */
   fun `vshorses$isShoed`(): Boolean
-
-  /** Gets item in the entity's horseshoe inventory slot. */
-  fun `vshorses$getHorseshoeInInventory`(): ItemStack
-
-  /** Sets item to the entity's horseshoe inventory slot. */
-  fun `vshorses$setHorseshoeInInventory`(stack: ItemStack)
 }

--- a/src/main/kotlin/com/vanillastar/vshorses/item/HorseshoeItem.kt
+++ b/src/main/kotlin/com/vanillastar/vshorses/item/HorseshoeItem.kt
@@ -5,10 +5,14 @@ import com.vanillastar.vshorses.entity.VSHorseEntity
 import com.vanillastar.vshorses.entity.isHorselike
 import com.vanillastar.vshorses.utils.getModIdentifier
 import net.fabricmc.fabric.api.item.v1.EnchantingContext
+import net.minecraft.component.type.AttributeModifierSlot
+import net.minecraft.component.type.AttributeModifiersComponent
 import net.minecraft.enchantment.Enchantment
 import net.minecraft.enchantment.Enchantments
+import net.minecraft.entity.EquipmentSlot
 import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.attribute.EntityAttributeModifier
+import net.minecraft.entity.attribute.EntityAttributes
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.Item
 import net.minecraft.item.ItemGroup
@@ -19,22 +23,28 @@ import net.minecraft.registry.RegistryKey
 import net.minecraft.registry.entry.RegistryEntry
 import net.minecraft.util.ActionResult
 import net.minecraft.util.Hand
-import net.minecraft.util.Identifier
 import net.minecraft.world.event.GameEvent
 import kotlin.jvm.optionals.getOrNull
 
+/** Modifiers to apply when horseshoe is equipped. */
+private val HORSESHOE_ITEM_MODIFIERS =
+  AttributeModifiersComponent.builder().add(
+    EntityAttributes.GENERIC_MOVEMENT_SPEED, EntityAttributeModifier(
+      getModIdentifier("horseshoe_speed_boost"),
+      0.15,
+      EntityAttributeModifier.Operation.ADD_VALUE
+    ), AttributeModifierSlot.FEET
+  ).build()
+
 abstract class HorseshoeItem: ModItem, Item(
   Settings().maxDamage(195)  // Same as iron boots
+    .attributeModifiers(HORSESHOE_ITEM_MODIFIERS)
 ) {
   override val id = getModIdentifier("horseshoe")
   override val itemGroup: RegistryKey<ItemGroup> = ItemGroups.COMBAT
 
-  /**
-   * Creates modifier for making horses faster when horseshoe is equipped.
-   */
-  fun getSpeedModifierWithId(id: Identifier) = EntityAttributeModifier(
-    id, 0.15, EntityAttributeModifier.Operation.ADD_VALUE
-  )
+  /** Equipment slot this item belongs in. */
+  val equipmentSlot = EquipmentSlot.FEET
 }
 
 @JvmField
@@ -69,7 +79,7 @@ val HORSESHOE_ITEM = object: HorseshoeItem() {
     }
 
     if (!user.world.isClient) {
-      entity.`vshorses$setHorseshoeInInventory`(stack.split(1))
+      entity.`vshorses$getHorseshoeInventory`().stack = stack.split(1)
       entity.world.emitGameEvent(entity, GameEvent.EQUIP, entity.pos)
     }
     return ActionResult.success(user.world.isClient)

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,7 @@
   "mixins": [
     "vshorses.mixins.json"
   ],
+  "accessWidener": "vshorses.accesswidener",
   "depends": {
     "fabricloader": ">=0.15.11",
     "minecraft": "~1.21",

--- a/src/main/resources/vshorses.accesswidener
+++ b/src/main/resources/vshorses.accesswidener
@@ -1,0 +1,3 @@
+accessWidener v2 named
+
+accessible class net/minecraft/screen/slot/ArmorSlot


### PR DESCRIPTION
Refactor horseshoe item to be stored in `AbstractHorseEntity` as an equipped item, with its own dedicated inventory. This approach also streamlines modifier application and inventory-handling, and allows horseshoe enchantments to be applied to the horse.