### PR TITLE
Make horse armor damageable & enchantable

### DIFF
--- a/src/main/java/com/vanillastar/vshorses/mixin/entity/AbstractHorseEntityMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/entity/AbstractHorseEntityMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.passive.AbstractHorseEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -131,6 +132,11 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
     return this.horseshoeInventory.getStack().isOf(HORSESHOE_ITEM);
   }
 
+  @Override
+  public void damageArmor(DamageSource source, float amount) {
+    this.damageEquipment(source, amount, EquipmentSlot.BODY);
+  }
+
   @Inject(
     method = "createBaseHorseAttributes",
     at = @At(value = "RETURN"),
@@ -149,7 +155,7 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
     @NotNull Vec3d movementInput,
     CallbackInfo ci
   ) {
-    if (!(this.getWorld() instanceof ServerWorld serverWorld) ||
+    if (!(this.getWorld() instanceof ServerWorld) ||
       !isHorselike(this) ||
       !this.vshorses$isShoed()) {
       return;
@@ -163,13 +169,7 @@ public abstract class AbstractHorseEntityMixin extends AnimalEntity implements V
     movingWhileRiddenTicks =
       (movingWhileRiddenTicks + 1) % TICKS_PER_HORSESHOE_DAMAGE;
     if (movingWhileRiddenTicks == 0) {
-      this.horseshoeInventory.getStack().damage(1, serverWorld, null, item -> {
-        // Volume and pitch from `LivingEntity.playEquipmentBreakEffects`.
-        this.playSound(item.getBreakSound(),
-          0.8F,
-          0.8F + this.getWorld().random.nextFloat() * 0.4F
-        );
-      });
+      this.horseshoeInventory.getStack().damage(1, this, EquipmentSlot.FEET);
     }
   }
 

--- a/src/main/java/com/vanillastar/vshorses/mixin/item/AnimalArmorItemMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/item/AnimalArmorItemMixin.java
@@ -1,0 +1,48 @@
+package com.vanillastar.vshorses.mixin.item;
+
+import net.fabricmc.fabric.api.item.v1.EnchantingContext;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.AnimalArmorItem;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.ArmorMaterial;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.tag.ItemTags;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(AnimalArmorItem.class)
+public abstract class AnimalArmorItemMixin extends ArmorItem {
+  @Shadow
+  @Final
+  private AnimalArmorItem.Type type;
+
+  private AnimalArmorItemMixin(
+    RegistryEntry<ArmorMaterial> material, Type type, Settings settings
+  ) {
+    super(material, type, settings);
+  }
+
+  @Override
+  public boolean isEnchantable(ItemStack stack) {
+    return type == AnimalArmorItem.Type.EQUESTRIAN;
+  }
+
+  @Override
+  public boolean canBeEnchantedWith(
+    ItemStack stack,
+    @NotNull RegistryEntry<Enchantment> enchantment,
+    @NotNull EnchantingContext context
+  ) {
+    Enchantment.Definition definition = enchantment.value().definition();
+    return (
+      switch (context) {
+        case PRIMARY ->
+          definition.primaryItems().orElse(definition.supportedItems());
+        case ACCEPTABLE -> definition.supportedItems();
+      }
+    ).stream().anyMatch(entry -> entry.isIn(ItemTags.CHEST_ARMOR_ENCHANTABLE));
+  }
+}

--- a/src/main/java/com/vanillastar/vshorses/mixin/item/ItemsMixin.java
+++ b/src/main/java/com/vanillastar/vshorses/mixin/item/ItemsMixin.java
@@ -1,0 +1,44 @@
+package com.vanillastar.vshorses.mixin.item;
+
+import net.minecraft.item.AnimalArmorItem;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.ArmorMaterial;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.registry.entry.RegistryEntry;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(Items.class)
+public abstract class ItemsMixin {
+  @ModifyArgs(
+    method = "<clinit>", at = @At(
+    value = "INVOKE",
+    target = "Lnet/minecraft/item/AnimalArmorItem;<init>(Lnet/minecraft/registry/entry/RegistryEntry;Lnet/minecraft/item/AnimalArmorItem$Type;ZLnet/minecraft/item/Item$Settings;)V"
+  )
+  )
+  private static void interceptRegisterHorseArmorItem(@NotNull Args args) {
+    RegistryEntry<ArmorMaterial> material = args.get(0);
+    AnimalArmorItem.Type type = args.get(1);
+    Item.Settings settings = args.get(3);
+
+    if (type != AnimalArmorItem.Type.EQUESTRIAN) {
+      return;
+    }
+    int maxDamageMultiplier = (
+      switch (material.getIdAsString()) {
+        case "minecraft:leather" -> 5;  // Same as leather armor
+        case "minecraft:iron" -> 7;  // Same as golden armor
+        case "minecraft:gold" -> 15;  // Same as iron armor
+        case "minecraft:diamond" -> 33;  // Same as diamond armor
+        default -> 0;  // Ignore
+      }
+    );
+    if (maxDamageMultiplier > 0) {
+      settings.maxDamage(ArmorItem.Type.BODY.getMaxDamage(maxDamageMultiplier));
+    }
+  }
+}

--- a/src/main/resources/vshorses.mixins.json
+++ b/src/main/resources/vshorses.mixins.json
@@ -5,6 +5,8 @@
   "mixins": [
     "block.DispenserBehaviorMixin",
     "entity.AbstractHorseEntityMixin",
+    "item.AnimalArmorItemMixin",
+    "item.ItemsMixin",
     "screen.HorseScreenHandlerMixin"
   ],
   "client": [


### PR DESCRIPTION
Make horse armor damageable and enchantable according to its material type. Any enchantments applicable to chestplates can be applied to horse armor.

Also streamline horseshoe enchantments to be any applicable to boots, minus a hardcoded list of generic armor enchantments.