### PR TITLE
Configure formatters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,6 @@ end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
-max_line_length = 80
+max_line_length = 100
 tab_width = 2
 trim_trailing_whitespace = true

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
   id 'fabric-loom' version '1.7-SNAPSHOT'
   id 'maven-publish'
   id "org.jetbrains.kotlin.jvm" version "2.0.0"
+  id "com.diffplug.spotless" version "7.0.0.BETA1"
 }
 
 version = project.mod_version
@@ -91,5 +92,29 @@ publishing {
     // Notice: This block does NOT have the same function as the block in the
     // top level. The repositories here will be used for publishing your
     // artifact, not for retrieving dependencies.
+  }
+}
+
+spotless {
+  ratchetFrom 'origin/main'
+
+  format 'misc', {
+    target '*.gradle', '.gitattributes', '.gitignore'
+
+    trimTrailingWhitespace()
+    indentWithSpaces(2)
+    endWithNewline()
+  }
+
+  java {
+    palantirJavaFormat(palantir_java_format_version).style("GOOGLE").formatJavadoc(true)
+  }
+
+  kotlin {
+    // version, style and all configurations here are optional
+    ktfmt(ktfmt_version).googleStyle().configure {
+      it.setBlockIndent(2)
+      it.setContinuationIndent(4)
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,7 @@ archives_base_name=vanillastar-horses
 
 # Dependencies.
 fabric_version=0.100.8+1.21
+
+# Formatter properties.
+palantir_java_format_version=2.50.0
+ktfmt_version=0.50


### PR DESCRIPTION
Configure formatters in Gradle:

- [Spotless](https://github.com/diffplug/spotless)
- Java: [Palantir Java Format](https://github.com/palantir/palantir-java-format) with Google style
- Kotlin: [ktfmt](https://github.com/facebook/ktfmt) with Google style

Not entirely happy with their prescribed style choices, but this is at least an improvement over the current local IDE-dependent setup.

Formatting will come in a later PR to keep diffs organized.