### PR TITLE
Fix leather horse armor & dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,8 +69,6 @@ tasks.named<ProcessResources>("processResources") {
             "version" to version,
             "minecraft_target_version" to minecraft_target_version,
             "fabric_loader_version" to fabric_loader_version,
-            "fabric_api_version" to fabric_api_version,
-            "fabric_kotlin_version" to fabric_kotlin_version,
         )
     )
   }

--- a/src/main/generated/assets/minecraft/models/item/leather_horse_armor.json
+++ b/src/main/generated/assets/minecraft/models/item/leather_horse_armor.json
@@ -63,7 +63,6 @@
     }
   ],
   "textures": {
-    "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay"
+    "layer0": "minecraft:item/leather_horse_armor"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_amethyst_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_amethyst_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_amethyst"
+    "layer1": "vshorses:trims/items/horse_armor_trim_amethyst"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_copper_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_copper_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_copper"
+    "layer1": "vshorses:trims/items/horse_armor_trim_copper"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_diamond_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_diamond_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_diamond"
+    "layer1": "vshorses:trims/items/horse_armor_trim_diamond"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_emerald_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_emerald_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_emerald"
+    "layer1": "vshorses:trims/items/horse_armor_trim_emerald"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_gold_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_gold_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_gold"
+    "layer1": "vshorses:trims/items/horse_armor_trim_gold"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_iron_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_iron_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_iron"
+    "layer1": "vshorses:trims/items/horse_armor_trim_iron"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_lapis_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_lapis_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_lapis"
+    "layer1": "vshorses:trims/items/horse_armor_trim_lapis"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_netherite_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_netherite_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_netherite"
+    "layer1": "vshorses:trims/items/horse_armor_trim_netherite"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_quartz_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_quartz_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_quartz"
+    "layer1": "vshorses:trims/items/horse_armor_trim_quartz"
   }
 }

--- a/src/main/generated/assets/vshorses/models/item/leather_horse_armor_redstone_trim.json
+++ b/src/main/generated/assets/vshorses/models/item/leather_horse_armor_redstone_trim.json
@@ -2,7 +2,6 @@
   "parent": "minecraft:item/generated",
   "textures": {
     "layer0": "minecraft:item/leather_horse_armor",
-    "layer1": "minecraft:item/leather_horse_armor_overlay",
-    "layer2": "vshorses:trims/items/horse_armor_trim_redstone"
+    "layer1": "vshorses:trims/items/horse_armor_trim_redstone"
   }
 }

--- a/src/main/kotlin/com/vanillastar/vshorses/VSHorsesDataGenerator.kt
+++ b/src/main/kotlin/com/vanillastar/vshorses/VSHorsesDataGenerator.kt
@@ -11,19 +11,14 @@ import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider
 import net.minecraft.data.client.*
-import net.minecraft.data.client.ItemModelGenerator.TrimMaterial
 import net.minecraft.data.server.recipe.RecipeExporter
 import net.minecraft.data.server.recipe.VanillaRecipeProvider
 import net.minecraft.item.AnimalArmorItem
-import net.minecraft.item.ArmorMaterial
-import net.minecraft.item.ArmorMaterials
 import net.minecraft.recipe.Ingredient
 import net.minecraft.recipe.SmithingTrimRecipe
 import net.minecraft.registry.Registries
 import net.minecraft.registry.RegistryWrapper.WrapperLookup
-import net.minecraft.registry.entry.RegistryEntry
 import net.minecraft.registry.tag.ItemTags
-import net.minecraft.util.Identifier
 
 class VSHorsesDataGenerator : DataGeneratorEntrypoint {
   /** Auto-generates all trim recipes for all horse armor. */
@@ -48,115 +43,58 @@ class VSHorsesDataGenerator : DataGeneratorEntrypoint {
 
   private inner class TrimmedHorseArmorItemModelProvider(output: FabricDataOutput) :
       FabricModelProvider(output) {
-    /** Recreates the item ID suffixed with the trim material. */
-    private fun getModIdentifierWithTrim(
-        itemModelGenerator: ItemModelGenerator,
-        itemId: Identifier,
-        trimMaterialName: String,
-    ) = getModIdentifier(itemModelGenerator.suffixTrim(itemId, trimMaterialName).path)
-
-    /** Recreates the item ID suffixed with the trim material. */
-    private fun getModIdentifierWithTrim(
-        itemModelGenerator: ItemModelGenerator,
-        itemId: Identifier,
-        trimMaterial: TrimMaterial,
-        armorMaterial: RegistryEntry<ArmorMaterial>,
-    ) =
-        getModIdentifierWithTrim(
-            itemModelGenerator,
-            itemId,
-            trimMaterial.getAppliedName(armorMaterial),
-        )
-
-    /** Generates JSON models for the horse armor item, with trim information. */
-    private fun generateHorseArmorItemModel(
-        itemModelGenerator: ItemModelGenerator,
-        modelId: Identifier,
-        textureId: Identifier,
-        textureOverlayId: Identifier?,
-        armorMaterial: RegistryEntry<ArmorMaterial>,
-    ) {
-      val (model, textureMap) =
-          if (textureOverlayId == null) {
-            Pair(Models.GENERATED, TextureMap.layer0(textureId))
-          } else {
-            Pair(Models.GENERATED_TWO_LAYERS, TextureMap.layered(textureId, textureOverlayId))
-          }
-      model.upload(modelId, textureMap, itemModelGenerator.writer) { id, textures ->
-        val jsonObj = Models.GENERATED_TWO_LAYERS.createJson(id, textures)
-        val overridesJsonArr = JsonArray()
-        for (trimMaterial in ItemModelGenerator.TRIM_MATERIALS) {
-          val predicateJsonObj = JsonObject()
-          predicateJsonObj.addProperty(
-              ItemModelGenerator.TRIM_TYPE.path,
-              trimMaterial.itemModelIndex,
-          )
-          val overrideJsonObj = JsonObject()
-          overrideJsonObj.addProperty(
-              "model",
-              getModIdentifierWithTrim(itemModelGenerator, id, trimMaterial, armorMaterial)
-                  .toString(),
-          )
-          overrideJsonObj.add("predicate", predicateJsonObj)
-          overridesJsonArr.add(overrideJsonObj)
-        }
-        jsonObj.add("overrides", overridesJsonArr)
-        jsonObj
-      }
-    }
-
-    /** Generates JSON models for trim overlays on horse armor items. */
-    private fun generateHorseArmorTrimItemModels(
-        itemModelGenerator: ItemModelGenerator,
-        modelId: Identifier,
-        textureId: Identifier,
-        textureOverlayId: Identifier?,
-        armorMaterial: RegistryEntry<ArmorMaterial>,
-    ) {
-      for (trimMaterial in ItemModelGenerator.TRIM_MATERIALS) {
-        val trimMaterialName = trimMaterial.getAppliedName(armorMaterial)
-        val trimTextureId = getModIdentifierWithTrim(itemModelGenerator, modelId, trimMaterialName)
-        val trimTextureOverlayId =
-            getModIdentifier("trims/items/horse_armor_trim_$trimMaterialName")
-
-        val (model, textureMap) =
-            if (textureOverlayId == null) {
-              Pair(Models.GENERATED_TWO_LAYERS, TextureMap.layered(textureId, trimTextureOverlayId))
-            } else {
-              Pair(
-                  Models.GENERATED_THREE_LAYERS,
-                  TextureMap.layered(textureId, textureOverlayId, trimTextureOverlayId),
-              )
-            }
-        model.upload(trimTextureId, textureMap, itemModelGenerator.writer)
-      }
-    }
-
     override fun generateItemModels(itemModelGenerator: ItemModelGenerator) {
       Registries.ITEM.filterIsInstance<AnimalArmorItem>()
           .filter { it.type == AnimalArmorItem.Type.EQUESTRIAN }
           .forEach {
             val modelId = ModelIds.getItemModelId(it)
             val textureId = TextureMap.getId(it)
-            val textureOverlayId =
-                if (it.material.value() == ArmorMaterials.LEATHER.value()) {
-                  TextureMap.getSubId(it, "_overlay")
-                } else null
 
-            generateHorseArmorItemModel(
-                itemModelGenerator,
+            // Generate JSON models for the horse armor item, with trim information.
+            Models.GENERATED.upload(
                 modelId,
-                textureId,
-                textureOverlayId,
-                it.material,
-            )
-            generateHorseArmorTrimItemModels(
-                itemModelGenerator,
-                modelId,
-                textureId,
-                textureOverlayId,
-                it.material,
-            )
+                TextureMap.layer0(textureId),
+                itemModelGenerator.writer,
+            ) { id, textures ->
+              val jsonObj = Models.GENERATED_TWO_LAYERS.createJson(id, textures)
+              val overridesJsonArr = JsonArray()
+              for (trimMaterial in ItemModelGenerator.TRIM_MATERIALS) {
+                val predicateJsonObj = JsonObject()
+                predicateJsonObj.addProperty(
+                    ItemModelGenerator.TRIM_TYPE.path,
+                    trimMaterial.itemModelIndex,
+                )
+                val overrideJsonObj = JsonObject()
+                overrideJsonObj.addProperty(
+                    "model",
+                    getModIdentifier(
+                            itemModelGenerator
+                                .suffixTrim(id, trimMaterial.getAppliedName(it.material))
+                                .path
+                        )
+                        .toString(),
+                )
+                overrideJsonObj.add("predicate", predicateJsonObj)
+                overridesJsonArr.add(overrideJsonObj)
+              }
+              jsonObj.add("overrides", overridesJsonArr)
+              jsonObj
+            }
+
+            // Generate JSON models for trim overlays on horse armor items.
+            for (trimMaterial in ItemModelGenerator.TRIM_MATERIALS) {
+              val trimMaterialName = trimMaterial.getAppliedName(it.material)
+              val trimTextureId =
+                  getModIdentifier(itemModelGenerator.suffixTrim(modelId, trimMaterialName).path)
+              val trimTextureOverlayId =
+                  getModIdentifier("trims/items/horse_armor_trim_$trimMaterialName")
+
+              Models.GENERATED_TWO_LAYERS.upload(
+                  trimTextureId,
+                  TextureMap.layered(textureId, trimTextureOverlayId),
+                  itemModelGenerator.writer,
+              )
+            }
           }
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,8 +27,7 @@
   "depends": {
     "fabricloader": ">=${fabric_loader_version}",
     "minecraft": "~${minecraft_target_version}",
-    "java": ">=21",
-    "fabric-api": ">=${fabric_api_version}",
-    "fabric-language-kotlin": ">=${fabric_kotlin_version}"
+    "fabric-api": "*",
+    "fabric-language-kotlin": "*"
   }
 }


### PR DESCRIPTION
Small fixes:

- Fix leather horse armor item rendering. Unlike leather armor, leather horse armor does not have an overlay.
- Fix Fabric dependency versioning to be more permissive.