### PR TITLE
Update versions & add menu links

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
         type: string
       minecraft-version:
         type: string
-      minecraft-target-version:
+      minecraft-target-versions:
         type: string
 
 permissions:
@@ -28,7 +28,7 @@ jobs:
         id: get-gradle-properties
         uses: ./.github/actions/read-gradle-properties
         with:
-          keys: java_version, mod_version, minecraft_version, minecraft_target_version
+          keys: java_version, mod_version, minecraft_version, minecraft_target_versions
 
       - name: Resolve environment variables
         run: |
@@ -42,8 +42,8 @@ jobs:
           if [ -n "${{ inputs.minecraft-version }}" ]; then \
             echo "MINECRAFT_VERSION='${{ inputs.minecraft-version }}'" >> $GITHUB_ENV; \
           fi
-          if [ -n "${{ inputs.minecraft-target-version }}" ]; then \
-            echo "MINECRAFT_TARGET_VERSION='${{ inputs.minecraft-target-version }}'" >> $GITHUB_ENV; \
+          if [ -n "${{ inputs.minecraft-target-versions }}" ]; then \
+            echo "MINECRAFT_TARGET_VERSIONS='${{ inputs.minecraft-target-versions }}'" >> $GITHUB_ENV; \
           fi
         shell: bash
 
@@ -60,7 +60,7 @@ jobs:
           version-type: release
 
           java: ${{ env.JAVA_VERSION }}
-          game-versions: ${{ env.MINECRAFT_TARGET_VERSION }}
+          game-versions: ${{ env.MINECRAFT_TARGET_VERSIONS }}
           files: build/libs/!(*-sources).jar
 
           github-generate-changelog: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   id("fabric-loom") version "1.7-SNAPSHOT"
   id("maven-publish")
-  id("org.jetbrains.kotlin.jvm") version "2.0.0"
-  id("com.diffplug.spotless") version "7.0.0.BETA1"
+  kotlin("jvm") version "2.0.20"
+  id("com.diffplug.spotless") version "7.0.0.BETA2"
 }
 
 val gradle_version: String by project
@@ -20,10 +20,11 @@ val archives_base_name: String by project
 val access_widener_path: String by project
 
 val minecraft_version: String by project
-val minecraft_target_version: String by project
+val minecraft_target_versions: String by project
 
 val fabric_yarn_mappings: String by project
 val fabric_loader_version: String by project
+val fabric_loader_target_versions: String by project
 val fabric_api_version: String by project
 val fabric_kotlin_version: String by project
 
@@ -69,9 +70,8 @@ tasks.named<ProcessResources>("processResources") {
     expand(
         mapOf(
             "version" to version,
-            "minecraft_version" to minecraft_version,
-            "minecraft_target_version" to minecraft_target_version,
-            "fabric_loader_version" to fabric_loader_version,
+            "minecraft_target_versions" to minecraft_target_versions,
+            "fabric_loader_target_versions" to fabric_loader_target_versions,
         )
     )
   }
@@ -106,7 +106,13 @@ extensions.configure<SpotlessExtension>("spotless") {
   ratchetFrom("origin/main")
 
   format("misc") {
-    target("*.gradle", ".git-blame-ignore-revs", ".gitignore")
+    target(
+        "*.gradle.*",
+        ".editorconfig",
+        ".git-blame-ignore-revs",
+        ".gitignore",
+        "gradle.properties",
+    )
 
     trimTrailingWhitespace()
     indentWithSpaces(2)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ gradle_version=8.10
 java_version=21
 
 # Mod properties.
-mod_version=1.0.1
+mod_version=1.0.0
 maven_group=com.vanillastar.horses
 archives_base_name=vanillastar-horses
 access_widener_path=src/main/resources/vshorses.accesswidener

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,24 +3,25 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
 # Build properties.
-gradle_version=8.8
+gradle_version=8.10
 java_version=21
 
 # Mod properties.
-mod_version=1.0.0
+mod_version=1.0.1
 maven_group=com.vanillastar.horses
 archives_base_name=vanillastar-horses
 access_widener_path=src/main/resources/vshorses.accesswidener
 
 # Minecraft properties.
-minecraft_version=1.21
-minecraft_target_version=1.21
+minecraft_version=1.21.1
+minecraft_target_versions=1.21.x
 
 # Fabric properties. See https://fabricmc.net/develop.
-fabric_yarn_mappings=1.21+build.9
-fabric_loader_version=0.15.11
-fabric_api_version=0.100.8+1.21
-fabric_kotlin_version=1.11.0+kotlin.2.0.0
+fabric_yarn_mappings=1.21.1+build.3
+fabric_loader_version=0.16.3
+fabric_loader_target_versions=>=0.15.11
+fabric_api_version=0.103.0+1.21.1
+fabric_kotlin_version=1.12.1+kotlin.2.0.20
 
 # Formatter properties.
 palantir_java_format_version=2.50.0

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "id": "vshorses",
-  "version": "${version}+${minecraft_version}",
+  "version": "${version}",
   "name": "Vanilla* Horses",
-  "description": "Makes horses a viable mode of transportation.",
+  "description": "Ride horses in your world again!",
   "authors": [
     "Sam Kim"
   ],
@@ -14,6 +14,16 @@
   },
   "license": "MIT",
   "icon" : "vshorses-icon.png",
+  "custom": {
+    "modmenu": {
+      "links": {
+        "modmenu.github_releases" : "https://github.com/sam-k/vanillastar-horses/releases",
+        "modmenu.modrinth" : "https://modrinth.com/mod/vanillastar-horses",
+        "modmenu.kofi" : "https://ko-fi.com/sam_k"
+      },
+      "update_checker": true
+    }
+  },
   "environment": "*",
   "entrypoints": {
     "fabric-datagen": [
@@ -31,8 +41,8 @@
   ],
   "accessWidener": "vshorses.accesswidener",
   "depends": {
-    "fabricloader": ">=${fabric_loader_version}",
-    "minecraft": "~${minecraft_target_version}",
+    "minecraft": "${minecraft_target_versions}",
+    "fabricloader": "${fabric_loader_target_versions}",
     "fabric-api": "*",
     "fabric-language-kotlin": "*"
   }


### PR DESCRIPTION
Update Minecraft to 1.21.1, add [Mod Menu](https://modrinth.com/mod/modmenu) links, and update the following dependencies:

- [Gradle](https://gradle.org/) 8.10
- [Kotlin JVM](https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm) 2.0.20
- [Spotless](https://github.com/diffplug/spotless) 7.0.0.BETA2
- [Fabric Yarn](https://github.com/FabricMC/yarn) 1.21.1+build.3
- [Fabric Loader](https://github.com/FabricMC/fabric-loader) 0.16.3
  - Target is left at [`>=0.15.11`](https://github.com/FabricMC/fabric-loader/releases/tag/0.15.11), the first update to support Minecraft 1.21.
- [Fabric API](https://modrinth.com/mod/fabric-api) 0.103.0+1.21.1
- [Fabric Language Kotlin](https://modrinth.com/mod/fabric-language-kotlin) 1.12.1+kotlin.2.0.20

This is mostly to test publishing.