### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,6 @@ jobs:
           github-tag: v${{ env.MOD_VERSION }}+${{ env.MINECRAFT_VERSION }}
           github-token: ${{ secrets.PUBLISH_GITHUB_TOKEN }}
 
-          modrinth-id: ${{ env.MODRINTH_ID }}
+          modrinth-id: ${{ vars.MODRINTH_ID }}
           modrinth-featured: true
           modrinth-token: ${{ secrets.PUBLISH_MODRINTH_TOKEN }}


### PR DESCRIPTION
Fix publish workflow to read the repo env var correctly.

Repo-level env vars live in `vars`, not `env`: [GitHub Docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#using-the-vars-context-to-access-configuration-variable-values)